### PR TITLE
Fix window unload guard in exercise

### DIFF
--- a/src/components/BreathingExercise/MixinLeaveExercise.vue
+++ b/src/components/BreathingExercise/MixinLeaveExercise.vue
@@ -42,18 +42,5 @@ export default defineComponent({
       this.showModal = false;
     },
   },
-
-  beforeMount() {
-    window.addEventListener("beforeunload", beforeunloadHander);
-  },
-  unmounted() {
-    window.removeEventListener("beforeunload", beforeunloadHander);
-  },
 });
-
-function beforeunloadHander(ev: Event) {
-  ev.preventDefault();
-  ev.returnValue = true;
-  return true;
-}
 </script>

--- a/src/store/modules/exercise/defaultState.ts
+++ b/src/store/modules/exercise/defaultState.ts
@@ -3,7 +3,6 @@ import { ExerciseState } from "./types";
 
 export const getProductionExerciseDefaultState = (): ExerciseState => ({
   started: false,
-  finished: false,
   disableAnimation: false,
   numberOfRounds: 3,
   breathsPerRound: 30,

--- a/src/store/modules/exercise/index.ts
+++ b/src/store/modules/exercise/index.ts
@@ -16,7 +16,6 @@ const getDefaultState =
     ? getProductionExerciseDefaultState
     : (): ExerciseState => ({
         started: false,
-        finished: false,
         disableAnimation: true,
         numberOfRounds: 3,
         breathsPerRound: 10,
@@ -38,7 +37,6 @@ customizableExerciseStateProps[0];
 
 function clearExerciseState(state: ExerciseState) {
   state.started = false;
-  state.finished = false;
   state.currentRoundState = RoundState.Stopped;
   state.holdTimes = [];
 }
@@ -52,6 +50,10 @@ export const exerciseStore: Module<ExerciseState, RootState> = {
       clearExerciseState(state);
       state.started = true;
       state.currentRoundState = RoundState.Breathing;
+    },
+    [ExerciseMutations.Finish]: (state) => {
+      state.started = false;
+      state.currentRoundState = RoundState.Stopped;
     },
     [ExerciseMutations.Cancel]: (state) => {
       clearExerciseState(state);

--- a/src/store/modules/exercise/types.ts
+++ b/src/store/modules/exercise/types.ts
@@ -2,7 +2,6 @@ import { RoundState } from "@/types/breath";
 
 export type ExerciseState = {
   started: boolean;
-  finished: boolean;
   disableAnimation: boolean;
   numberOfRounds: number;
   breathsPerRound: number;
@@ -14,6 +13,7 @@ export type ExerciseState = {
 
 export enum ExerciseMutations {
   Start = "START_EXERCISE",
+  Finish = "FINISH_EXERCISE",
   Cancel = "CANCEL_EXERCISE",
   SetRoundState = "SET_ROUND_STATUS",
   AddHoldTime = "ADD_HOLD_TIME",

--- a/src/views/BreathingExercise.vue
+++ b/src/views/BreathingExercise.vue
@@ -8,8 +8,25 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
+function beforeWindowUnloadHander(ev: Event) {
+  ev.preventDefault();
+  ev.returnValue = true;
+  return true;
+}
+
 export default defineComponent({
   name: "BreathingExercise",
+
+  watch: {
+    "$store.state.exercise.started"(val) {
+      console.log(val);
+      if (val) {
+        window.addEventListener("beforeunload", beforeWindowUnloadHander);
+      } else {
+        window.removeEventListener("beforeunload", beforeWindowUnloadHander);
+      }
+    },
+  },
 });
 </script>
 

--- a/src/views/BreathingExerciseSummary.vue
+++ b/src/views/BreathingExerciseSummary.vue
@@ -135,10 +135,7 @@ export default defineComponent({
   },
 
   mounted() {
-    this.$store.commit(
-      namespaceName("exercise", ExerciseMutations.SetRoundState),
-      RoundState.Stopped
-    );
+    this.$store.commit(namespaceName("exercise", ExerciseMutations.Finish));
   },
 });
 </script>


### PR DESCRIPTION
attaches handler when exercise starts
and detaches on finish/cancel
instead of add/remove it in the lifecycle hooks 
of the exercise screens